### PR TITLE
test: check oapi-codegen works

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,3 +22,10 @@ jobs:
           touch *.yaml
           make generate-json
           git diff --exit-code
+
+  oapi_codegen:
+    runs-on: "ubuntu-latest"
+    container: registry.access.redhat.com/ubi9/go-toolset:1.18
+    steps:
+      - uses: "actions/checkout@v3"
+      - run: make oapi-codegen

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /.venv
 /node_modules
+/bin
+/tmp

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ VENV = $(srcdir)/.venv
 PYTHON_VENV = $(VENV)/bin/python
 VALIDATOR = $(VENV)/bin/openapi-spec-validator
 NODE_BIN = node_modules/.bin
+BIN = bin
+TMP = tmp
+OAPI_CODEGEN = $(BIN)/oapi-codegen
+OAPI_CODEGEN_VERSION ?= v1.12.4
 
 SWAGGER_CONTAINER = swagger-editor
 
@@ -12,12 +16,14 @@ SWAGGER_CONTAINER = swagger-editor
 all:
 	$(MAKE) openapi-sort
 	$(MAKE) validate
+	$(MAKE) oapi-codegen
 	$(MAKE) vacuum
 	$(MAKE) generate-json
 
 .PHONY: clean
 clean:
-	rm -rf $(VENV)
+	rm -rf $(VENV) $(BIN) $(TMP)
+
 
 $(PYTHON_VENV):
 	$(PYTHON) -m venv $(VENV)
@@ -29,6 +35,27 @@ $(VALIDATOR): $(PYTHON_VENV)
 $(NODE_BIN)/%: package.json package-lock.json
 	npm install
 	touch $(NODE_BIN)/*
+
+$(OAPI_CODEGEN):
+	GOBIN=$(CURDIR)/$(BIN) go install github.com/deepmap/oapi-codegen/cmd/oapi-codegen@$(OAPI_CODEGEN_VERSION)
+
+.PHONY: oapi-codegen
+oapi-codegen: \
+		$(TMP)/public/spec.gen.go $(TMP)/public/server.gen.go $(TMP)/public/types.gen.go \
+		$(TMP)/internal/spec.gen.go $(TMP)/internal/server.gen.go $(TMP)/internal/types.gen.go \
+		$(TMP)/metrics/spec.gen.go $(TMP)/metrics/server.gen.go $(TMP)/metrics/types.gen.go
+
+$(TMP)/%/spec.gen.go: %.openapi.yaml $(OAPI_CODEGEN)
+	@mkdir -p $(dir $@)
+	$(OAPI_CODEGEN) -generate spec -package $* -o $(TMP)/$*/spec.gen.go $<
+
+$(TMP)/%/server.gen.go: %.openapi.yaml $(OAPI_CODEGEN)
+	@mkdir -p $(dir $@)
+	$(OAPI_CODEGEN) -generate server -package $* -o $(TMP)/$*/server.gen.go $<
+
+$(TMP)/%/types.gen.go: %.openapi.yaml $(OAPI_CODEGEN)
+	@mkdir -p $(dir $@)
+	$(OAPI_CODEGEN) -generate types -package $* -o $(TMP)/$*/types.gen.go $<
 
 .PHONY: validate
 validate: $(VALIDATOR)


### PR DESCRIPTION
The backend repo uses `oapi-codegen` to generate Go bindings from OpenAPI spec. There are some corner cases where normal validation passes but `oapi-codegen` can fail. Add an additional check to verify Go bindings can be generated.