### PR TITLE
HMS-2459 feat: Add security scope information

### DIFF
--- a/public.openapi.json
+++ b/public.openapi.json
@@ -77,7 +77,9 @@
         },
         "security": [
           {
-            "x-rh-identity": []
+            "x-rh-identity": [
+              "Type:User"
+            ]
           }
         ],
         "tags": [
@@ -117,7 +119,9 @@
         },
         "security": [
           {
-            "x-rh-identity": []
+            "x-rh-identity": [
+              "Type:User"
+            ]
           }
         ],
         "tags": [
@@ -161,7 +165,9 @@
         },
         "security": [
           {
-            "x-rh-identity": []
+            "x-rh-identity": [
+              "Type:User"
+            ]
           }
         ],
         "tags": [
@@ -189,7 +195,9 @@
         },
         "security": [
           {
-            "x-rh-identity": []
+            "x-rh-identity": [
+              "Type:User"
+            ]
           }
         ],
         "tags": [
@@ -213,7 +221,9 @@
         },
         "security": [
           {
-            "x-rh-identity": []
+            "x-rh-identity": [
+              "Type:User"
+            ]
           }
         ],
         "tags": [
@@ -277,7 +287,12 @@
         },
         "security": [
           {
-            "x-rh-identity": []
+            "x-rh-identity": [
+              "Type:System"
+            ]
+          },
+          {
+            "x-rh-idm-registration-token": []
           }
         ],
         "tags": [
@@ -330,7 +345,9 @@
         },
         "security": [
           {
-            "x-rh-identity": []
+            "x-rh-identity": [
+              "Type:System:domain"
+            ]
           }
         ],
         "tags": [
@@ -394,7 +411,9 @@
         },
         "security": [
           {
-            "x-rh-identity": []
+            "x-rh-identity": [
+              "Type:System:domain"
+            ]
           }
         ],
         "tags": [
@@ -1527,7 +1546,13 @@
     "securitySchemes": {
       "x-rh-identity": {
         "name": "X-Rh-Identity",
-        "description": "Base64-encoded JSON identity header provided by 3Scale. It contains type (System, User), org_id, and either username or certificate CN.",
+        "description": "Base64-encoded JSON identity header provided by 3Scale API gateway.\nThe JSON object contains type (System, User), org_id, and either username or certificate CN.\nScopes:\n- 'Type:User' for user access\n- 'Type:System': for system access (hosts with RHSM mTLS auth)\n- 'Type:System:domain' for system access, limited to host's domain\n",
+        "type": "apiKey",
+        "in": "header"
+      },
+      "x-rh-idm-registration-token": {
+        "name": "X-Rh-Idm-Registration-Token",
+        "description": "One-time Domain Registration Token to authenticate domain registration with ipa-hcc command.",
         "type": "apiKey",
         "in": "header"
       }

--- a/public.openapi.yaml
+++ b/public.openapi.yaml
@@ -53,7 +53,8 @@ paths:
                 '404':
                     $ref: '#/components/responses/ErrorResponse'
             security:
-                - x-rh-identity: []
+                - x-rh-identity:
+                      - Type:User
             tags:
                 - resources
         parameters:
@@ -77,7 +78,8 @@ paths:
                 '404':
                     $ref: '#/components/responses/ErrorResponse'
             security:
-                - x-rh-identity: []
+                - x-rh-identity:
+                      - Type:User
             tags:
                 - resources
     /domains/token:
@@ -104,7 +106,8 @@ paths:
                 '404':
                     $ref: '#/components/responses/ErrorResponse'
             security:
-                - x-rh-identity: []
+                - x-rh-identity:
+                      - Type:User
             tags:
                 - resources
     /domains/{uuid}:
@@ -122,7 +125,8 @@ paths:
                 '404':
                     $ref: '#/components/responses/ErrorResponse'
             security:
-                - x-rh-identity: []
+                - x-rh-identity:
+                      - Type:User
             tags:
                 - resources
         get:
@@ -137,7 +141,8 @@ paths:
                 '404':
                     $ref: '#/components/responses/ErrorResponse'
             security:
-                - x-rh-identity: []
+                - x-rh-identity:
+                      - Type:User
             tags:
                 - resources
         parameters:
@@ -174,7 +179,9 @@ paths:
                 '404':
                     $ref: '#/components/responses/ErrorResponse'
             security:
-                - x-rh-identity: []
+                - x-rh-identity:
+                      - Type:System
+                - x-rh-idm-registration-token: []
             tags:
                 - actions
     /domains/{uuid}/update:
@@ -205,7 +212,8 @@ paths:
                 '404':
                     $ref: '#/components/responses/ErrorResponse'
             security:
-                - x-rh-identity: []
+                - x-rh-identity:
+                      - Type:System:domain
             tags:
                 - actions
     /host-conf/{inventory_id}/{fqdn}:
@@ -245,7 +253,8 @@ paths:
                 '200':
                     $ref: '#/components/responses/HostConfResponse'
             security:
-                - x-rh-identity: []
+                - x-rh-identity:
+                      - Type:System:domain
             tags:
                 - actions
 components:
@@ -1121,7 +1130,18 @@ components:
     securitySchemes:
         x-rh-identity:
             name: X-Rh-Identity
-            description: Base64-encoded JSON identity header provided by 3Scale. It contains type (System, User), org_id, and either username or certificate CN.
+            description: |
+                Base64-encoded JSON identity header provided by 3Scale API gateway.
+                The JSON object contains type (System, User), org_id, and either username or certificate CN.
+                Scopes:
+                - 'Type:User' for user access
+                - 'Type:System': for system access (hosts with RHSM mTLS auth)
+                - 'Type:System:domain' for system access, limited to host's domain
+            type: apiKey
+            in: header
+        x-rh-idm-registration-token:
+            name: X-Rh-Idm-Registration-Token
+            description: One-time Domain Registration Token to authenticate domain registration with ipa-hcc command.
             type: apiKey
             in: header
 security:


### PR DESCRIPTION
`x-rh-identity` security information of routes now contain information whether a user or a system is permitted to access an API endpoint. Systems can be restricted to self-service of their own domain.

The registration route now has `x-rh-idm-registration-token` security information.