### PR TITLE
fix: add pagination-ref format

### DIFF
--- a/public.openapi.json
+++ b/public.openapi.json
@@ -1334,22 +1334,26 @@
           "first": {
             "description": "Reference to the first page of the request.",
             "type": "string",
-            "format": "url"
+            "format": "pagination-ref",
+            "pattern": "^(\\/\\w+){4}\\?(offset|limit)=(0|[1-9]\\d*)\\&(offset|limit)=(0|[1-9]\\d*)$"
           },
           "last": {
             "description": "Reference to the last page of the request.",
             "type": "string",
-            "format": "url"
+            "format": "pagination-ref",
+            "pattern": "^(\\/\\w+){4}\\?(offset|limit)=(0|[1-9]\\d*)\\&(offset|limit)=(0|[1-9]\\d*)$"
           },
           "next": {
             "description": "Reference to the next page of the request.",
             "type": "string",
-            "format": "url"
+            "format": "pagination-ref",
+            "pattern": "^(\\/\\w+){4}\\?(offset|limit)=(0|[1-9]\\d*)\\&(offset|limit)=(0|[1-9]\\d*)$"
           },
           "previous": {
             "description": "Reference to the previous page of the request.",
             "type": "string",
-            "format": "url"
+            "format": "pagination-ref",
+            "pattern": "^(\\/\\w+){4}\\?(offset|limit)=(0|[1-9]\\d*)\\&(offset|limit)=(0|[1-9]\\d*)$"
           }
         },
         "example": {

--- a/public.openapi.yaml
+++ b/public.openapi.yaml
@@ -948,19 +948,23 @@ components:
                 first:
                     description: Reference to the first page of the request.
                     type: string
-                    format: url
+                    format: pagination-ref
+                    pattern: ^(\/\w+){4}\?(offset|limit)=(0|[1-9]\d*)\&(offset|limit)=(0|[1-9]\d*)$
                 last:
                     description: Reference to the last page of the request.
                     type: string
-                    format: url
+                    format: pagination-ref
+                    pattern: ^(\/\w+){4}\?(offset|limit)=(0|[1-9]\d*)\&(offset|limit)=(0|[1-9]\d*)$
                 next:
                     description: Reference to the next page of the request.
                     type: string
-                    format: url
+                    format: pagination-ref
+                    pattern: ^(\/\w+){4}\?(offset|limit)=(0|[1-9]\d*)\&(offset|limit)=(0|[1-9]\d*)$
                 previous:
                     description: Reference to the previous page of the request.
                     type: string
-                    format: url
+                    format: pagination-ref
+                    pattern: ^(\/\w+){4}\?(offset|limit)=(0|[1-9]\d*)\&(offset|limit)=(0|[1-9]\d*)$
             example:
                 first: /api/idm/v1/domains?limit=10&offset=0
                 last: /api/idm/v1/domains?limit=10&offset=10


### PR DESCRIPTION
This change add pagination-ref format to the pagination metadata. This allows to align the response with the platform guidelines; this update PaginationLinks schema.