### PR TITLE
HMS-2590 fix: update tags for patch /domoains/:domain_id

### DIFF
--- a/public.openapi.json
+++ b/public.openapi.json
@@ -286,7 +286,7 @@
           }
         ],
         "tags": [
-          "actions"
+          "resources"
         ]
       },
       "put": {

--- a/public.openapi.yaml
+++ b/public.openapi.yaml
@@ -176,7 +176,7 @@ paths:
                 - x-rh-identity:
                       - Type:User
             tags:
-                - actions
+                - resources
         put:
             description: Update the rhel-idm domain information.
             summary: Update domain information by ipa-hcc agent.


### PR DESCRIPTION
This change update the tags for PATCH /domains/:domain_id operation, from `actions` to `resources`. The impact of this change is that the wrapper for the client generated, is gathered in the same factory class, so we will use the endpoint by `resources_api.patchDomain(...)`.