### PR TITLE
doc: RDN values and create-only attributes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
 
   oapi_codegen:
     runs-on: "ubuntu-latest"
-    container: registry.access.redhat.com/ubi9/go-toolset:1.18
+    container: registry.access.redhat.com/ubi9/go-toolset:1.20
     steps:
       - uses: "actions/checkout@v3"
       - run: make oapi-codegen

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ NODE_BIN = node_modules/.bin
 BIN = bin
 TMP = tmp
 OAPI_CODEGEN = $(BIN)/oapi-codegen
-OAPI_CODEGEN_VERSION ?= v1.12.4
+OAPI_CODEGEN_VERSION ?= v1.14.0
 
 SWAGGER_CONTAINER = swagger-editor
 

--- a/public.openapi.json
+++ b/public.openapi.json
@@ -1095,6 +1095,12 @@
         ],
         "additionalProperties": false,
         "properties": {
+          "automount_location": {
+            "description": "Automount location name for ipa-client-automount",
+            "type": "string",
+            "minLength": 1,
+            "example": "default"
+          },
           "cabundle": {
             "$ref": "#/components/schemas/CaCertBundle"
           },
@@ -1112,7 +1118,7 @@
             "items": {
               "type": "string"
             },
-            "example": "[\"--automount-location=default\", \"--enable-dns-updates\"]"
+            "example": "[\"--enable-dns-updates\"]"
           },
           "realm_name": {
             "$ref": "#/components/schemas/RealmName"

--- a/public.openapi.yaml
+++ b/public.openapi.yaml
@@ -770,6 +770,11 @@ components:
                 - realm_name
             additionalProperties: false
             properties:
+                automount_location:
+                    description: Automount location name for ipa-client-automount
+                    type: string
+                    minLength: 1
+                    example: default
                 cabundle:
                     $ref: '#/components/schemas/CaCertBundle'
                 enrollment_servers:
@@ -783,7 +788,7 @@ components:
                     type: array
                     items:
                         type: string
-                    example: '["--automount-location=default", "--enable-dns-updates"]'
+                    example: '["--enable-dns-updates"]'
                 realm_name:
                     $ref: '#/components/schemas/RealmName'
             x-rh-ipa-hcc:


### PR DESCRIPTION
The automount location used to be an `ipa-client-install` argument. However the approach has to issues:

1. `ipa-client-install --automount-location` is currently broken and wont't get fixed in time for next internal demo, see https://pagure.io/freeipa/issue/9487
2. For NFS automount of home directories, the SELinux boolean `use_nfs_home_dirs` must be enabled first.

The new API has the automount location in a new field, so `ipahcc-auto-enrollment` can run `ipa-client-automount` and `setsebool` after `ipa-client-install`.

IPA's automount location is an RDN attribute,
`cn=name,cn=automount,$SUFFIX`.

Also syncs golang version and oapi-codegen version with backend.