### PR TITLE
HMS-3429: remove RealmName pattern

### DIFF
--- a/public.openapi.json
+++ b/public.openapi.json
@@ -1433,7 +1433,6 @@
         "format": "realm",
         "maxLength": 253,
         "minLength": 3,
-        "pattern": "^[A-Z0-9\\.\\-]+$",
         "x-rh-ipa-hcc": {
           "type": "defs"
         },

--- a/public.openapi.yaml
+++ b/public.openapi.yaml
@@ -1034,7 +1034,6 @@ components:
             format: realm
             maxLength: 253
             minLength: 3
-            pattern: ^[A-Z0-9\.\-]+$
             x-rh-ipa-hcc:
                 type: defs
             example: DOMAIN.EXAMPLE


### PR DESCRIPTION
KerberosRealm is defined in RFC 4120 as:

```
KerberosString  ::= GeneralString (IA5String)
Realm           ::= KerberosString
```

So any string of ASCII printables is valid.  Remove the regex pattern which is too tight.

Related: https://issues.redhat.com/browse/HMS-3429