### PR TITLE
feat(HMS-4274): support service accounts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ VALIDATOR = $(VENV)/bin/openapi-spec-validator
 NODE_BIN = node_modules/.bin
 BIN = bin
 TMP = tmp
-OAPI_CODEGEN = $(BIN)/oapi-codegen
 OAPI_CODEGEN_VERSION ?= v1.14.0
 
 SWAGGER_CONTAINER = swagger-editor
@@ -16,7 +15,6 @@ SWAGGER_CONTAINER = swagger-editor
 all:
 	$(MAKE) openapi-sort
 	$(MAKE) validate
-	$(MAKE) oapi-codegen
 	$(MAKE) vacuum
 	$(MAKE) generate-json
 

--- a/public.openapi.json
+++ b/public.openapi.json
@@ -83,7 +83,8 @@
         "security": [
           {
             "x-rh-identity": [
-              "Type:User"
+              "Type:User",
+              "Type:ServiceAccount"
             ]
           }
         ],
@@ -177,7 +178,8 @@
         "security": [
           {
             "x-rh-identity": [
-              "Type:User"
+              "Type:User",
+              "Type:ServiceAccount"
             ]
           }
         ],
@@ -215,7 +217,8 @@
         "security": [
           {
             "x-rh-identity": [
-              "Type:User"
+              "Type:User",
+              "Type:ServiceAccount"
             ]
           }
         ],
@@ -241,7 +244,8 @@
         "security": [
           {
             "x-rh-identity": [
-              "Type:User"
+              "Type:User",
+              "Type:ServiceAccount"
             ]
           }
         ],
@@ -281,7 +285,8 @@
         "security": [
           {
             "x-rh-identity": [
-              "Type:User"
+              "Type:User",
+              "Type:ServiceAccount"
             ]
           }
         ],
@@ -428,7 +433,8 @@
           {
             "x-rh-identity": [
               "Type:System",
-              "Type:User"
+              "Type:User",
+              "Type:ServiceAccount"
             ]
           }
         ],
@@ -1547,7 +1553,7 @@
     "securitySchemes": {
       "x-rh-identity": {
         "name": "X-Rh-Identity",
-        "description": "Base64-encoded JSON identity header provided by 3Scale API gateway.\nThe JSON object contains type (System, User), org_id, and either username or certificate CN.\nScopes:\n- 'Type:User' for user access\n- 'Type:System': for system access (hosts with RHSM mTLS auth)\n- 'Type:System:domain' for system access, limited to host's domain\n",
+        "description": "Base64-encoded JSON identity header provided by 3Scale API gateway.\nThe JSON object contains type (System, User), org_id, and either username or certificate CN.\nScopes:\n- 'Type:User' for user access\n- 'Type:ServiceAccount' for service accounts\n- 'Type:System': for system access (hosts with RHSM mTLS auth)\n- 'Type:System:domain' for system access, limited to host's domain\n",
         "type": "apiKey",
         "in": "header"
       },

--- a/public.openapi.yaml
+++ b/public.openapi.yaml
@@ -57,6 +57,7 @@ paths:
             security:
                 - x-rh-identity:
                       - Type:User
+                      - Type:ServiceAccount
             tags:
                 - resources
         post:
@@ -112,6 +113,7 @@ paths:
             security:
                 - x-rh-identity:
                       - Type:User
+                      - Type:ServiceAccount
             tags:
                 - resources
     /domains/{uuid}:
@@ -134,6 +136,7 @@ paths:
             security:
                 - x-rh-identity:
                       - Type:User
+                      - Type:ServiceAccount
             tags:
                 - resources
         get:
@@ -150,6 +153,7 @@ paths:
             security:
                 - x-rh-identity:
                       - Type:User
+                      - Type:ServiceAccount
             tags:
                 - resources
         patch:
@@ -175,6 +179,7 @@ paths:
             security:
                 - x-rh-identity:
                       - Type:User
+                      - Type:ServiceAccount
             tags:
                 - resources
         put:
@@ -266,6 +271,7 @@ paths:
                 - x-rh-identity:
                       - Type:System
                       - Type:User
+                      - Type:ServiceAccount
             tags:
                 - resources
 components:
@@ -1123,6 +1129,7 @@ components:
                 The JSON object contains type (System, User), org_id, and either username or certificate CN.
                 Scopes:
                 - 'Type:User' for user access
+                - 'Type:ServiceAccount' for service accounts
                 - 'Type:System': for system access (hosts with RHSM mTLS auth)
                 - 'Type:System:domain' for system access, limited to host's domain
             type: apiKey

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
-yamlfix
-openapi-spec-validator
+pyyaml>=6.0.0,<6.1.0
+yamlfix>=1.16.0,<1.17.0
+openapi-spec-validator>=0.7.1,<0.8.0
 


### PR DESCRIPTION
Add extended information to provide when an endpoint could be used for a service account.

This allow to generate code providing the information into the context.