### PR TITLE
add explicit error status codes for host-conf

### DIFF
--- a/public.openapi.json
+++ b/public.openapi.json
@@ -392,6 +392,26 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/HostConfResponse"
+          },
+          "404": {
+            "description": "No enabled domains matched request parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Multiple active domains matched request parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Errors"
+                }
+              }
+            }
           }
         },
         "security": [

--- a/public.openapi.yaml
+++ b/public.openapi.yaml
@@ -245,6 +245,18 @@ paths:
             responses:
                 '200':
                     $ref: '#/components/responses/HostConfResponse'
+                '404':
+                    description: No enabled domains matched request parameters
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Errors'
+                '409':
+                    description: Multiple active domains matched request parameters
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Errors'
             security:
                 - x-rh-identity:
                       - Type:System:domain


### PR DESCRIPTION
The host-conf resource returns 404 and 409 statuses for specific semantic conditions.  Add these responses codes to the response list.  Distinct and specific descriptions are given to document the semantics, instead of referencing ErrorResponse with its generic description.

This minor change is mainly for documenting the API better.  It does not need to be propagated to the downstream repos but can wait for whenever a more important change occurs.