### PR TITLE
fix(HMS-3152): LocationName regex to allow uppercase

### DIFF
--- a/public.openapi.json
+++ b/public.openapi.json
@@ -1373,7 +1373,7 @@
         "type": "string",
         "maxLength": 63,
         "minLength": 1,
-        "pattern": "^[a-z][a-z0-9\\-]*$",
+        "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9\\-]*[a-zA-Z0-9])*$",
         "x-rh-ipa-hcc": {
           "type": "defs"
         },

--- a/public.openapi.yaml
+++ b/public.openapi.yaml
@@ -979,7 +979,7 @@ components:
             type: string
             maxLength: 63
             minLength: 1
-            pattern: ^[a-z][a-z0-9\-]*$
+            pattern: ^[a-zA-Z0-9]([a-zA-Z0-9\-]*[a-zA-Z0-9])*$
             x-rh-ipa-hcc:
                 type: defs
             example: alpha


### PR DESCRIPTION
As DNS labels are case insensitive and RFC 1035 allows upper case.

Before this change the regex was more restricitive than what was possible to define in IPA location.