### PR TITLE
fix(HMS-3152): remove pattern matching from location name

### DIFF
--- a/public.openapi.json
+++ b/public.openapi.json
@@ -1373,7 +1373,6 @@
         "type": "string",
         "maxLength": 63,
         "minLength": 1,
-        "pattern": "^[a-z][a-z0-9\\-]*$",
         "x-rh-ipa-hcc": {
           "type": "defs"
         },

--- a/public.openapi.yaml
+++ b/public.openapi.yaml
@@ -974,12 +974,12 @@ components:
                 type: defs
             x-rh-rdn-value: name
         LocationName:
+            # validation pattern was removed to not be more restrictive than IPA server
             title: Location identifier (IPA location, AD site)
             description: A location identifier (lower-case DNS label)
             type: string
             maxLength: 63
             minLength: 1
-            pattern: ^[a-z][a-z0-9\-]*$
             x-rh-ipa-hcc:
                 type: defs
             example: alpha


### PR DESCRIPTION
Location name should be a DNS label and could be matched by a regex.

Correct one could be `"^[a-zA-Z0-9]([a-zA-Z0-9\\-]*[a-zA-Z0-9])*$".`

PR https://github.com/podengo-project/idmsvc-api/pull/21 has a discussion about it. But users can defined more values in IPA location in the FreeIPA server than what the RFCs allow.

From this PoV, it is more important for idmsvc to pass registration even with slightly invalid DNS label than being valid but failing. Idmsvc doesn't use the value for DNS operations.